### PR TITLE
Use explicit GHA token permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,9 @@ name: pre-commit
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/OJFord/amail/security/code-scanning/1](https://github.com/OJFord/amail/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is least-privileged by default.  
Best single fix here: define workflow-level permissions directly under `on:` (or near the top-level keys) with `contents: read`, since the displayed steps only require repository read access (checkout + local tooling). This preserves current functionality while satisfying CodeQL and preventing accidental broader access if defaults change.

Edit only `.github/workflows/lint.yml`, inserting:

- `permissions:`
- `  contents: read`

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
