### PR TITLE
Fix email age persisted across tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/
 .terraform.lock.hcl
 
 /lambda-smtp-relay/Cargo.lock
+node_modules/

--- a/eml-client/src/components/RelativeDate.svelte
+++ b/eml-client/src/components/RelativeDate.svelte
@@ -45,7 +45,7 @@
     return fullDate.format(date)
   }
 
-  let formattedDate = $state(formatDate(date))
+  let formattedDate = $derived(formatDate(date))
   $effect(() => {
     const msHour = 1000 * 60 * 60
     const id = setInterval(

--- a/eml-client/src/components/RelativeDate.svelte
+++ b/eml-client/src/components/RelativeDate.svelte
@@ -45,8 +45,10 @@
     return fullDate.format(date)
   }
 
-  let formattedDate = $derived(formatDate(date))
+  let formattedDate = $state(formatDate(date))
   $effect(() => {
+    formattedDate = formatDate(date)
+
     const msHour = 1000 * 60 * 60
     const id = setInterval(
       () => (formattedDate = formatDate(date)),


### PR DESCRIPTION
Presently the email age ('20 minutes ago', etc.) is persisted on changing between tabs/tag views for each element in the list.

This fixes it to recompute for the emails shown in that view on change.